### PR TITLE
Show original plot settings by menu

### DIFF
--- a/R/helpers_plots.R
+++ b/R/helpers_plots.R
@@ -522,7 +522,7 @@ extract_plot_settings <- function(rv, index, plot_obj) {
 	}
 	
 	# Store ALL original values
-	rv$originals[[index_str]] <- list(
+	orig <- list(
 		# Labels
 		title      = get_lab("title"),
 		subtitle   = get_lab("subtitle"),
@@ -575,6 +575,65 @@ extract_plot_settings <- function(rv, index, plot_obj) {
 		legend_title_size = BASE$legend_title_size,
 		legend_text_size = BASE$legend_text_size
 	)
+
+	# Build a parallel source map indicating origin of each value
+	src <- list()
+
+	# Labels: treat non-empty as from plot
+	src$title    <- if (nzchar(orig$title)) "plot" else "missing"
+	src$subtitle <- if (nzchar(orig$subtitle)) "plot" else "missing"
+	src$caption  <- if (nzchar(orig$caption)) "plot" else "missing"
+	src$xlab     <- if (nzchar(orig$xlab)) "plot" else "missing"
+	src$ylab     <- if (nzchar(orig$ylab)) "plot" else "missing"
+
+	# Theme/base defaults
+	src$theme      <- "base"
+	src$base_size  <- "base"
+	src$legend_pos <- "base"
+	src$legend_box <- if (!is.null(lbox)) "plot" else "missing"
+	src$panel_bg   <- "missing"
+	src$plot_bg    <- "missing"
+
+	# Grid-related settings
+	src$grid_major            <- if (!is.null(maj_el)) "plot" else "base"
+	src$grid_minor            <- if (!is.null(min_el)) "plot" else "base"
+	src$grid_major_linetype   <- if (!is.null(maj_el)) "plot" else "base"
+	src$grid_minor_linetype   <- if (!is.null(min_el)) "plot" else "base"
+	src$grid_color            <- "missing"
+
+	# Axis
+	src$x_min <- if (!is.null(orig$x_min)) "plot" else "missing"
+	src$x_max <- if (!is.null(orig$x_max)) "plot" else "missing"
+	src$y_min <- if (!is.null(orig$y_min)) "plot" else "missing"
+	src$y_max <- if (!is.null(orig$y_max)) "plot" else "missing"
+
+	# Steps are derived suggestions
+	src$x_step_major <- if (!is.null(x_info$step_major)) "plot" else "derived"
+	src$x_step_minor <- if (!is.null(x_info$step_minor)) "plot" else "derived"
+	src$y_step_major <- if (!is.null(y_info$step_major)) "plot" else "derived"
+	src$y_step_minor <- if (!is.null(y_info$step_minor)) "plot" else "derived"
+
+	# Colors/palettes
+	src$palette                     <- "base"
+	src$continuous_colour_palette   <- if (is.null(continuous_colour_palette)) "missing" else "derived"
+	src$continuous_fill_palette     <- if (is.null(continuous_fill_palette)) "missing" else "derived"
+	src$colour_levels               <- if (length(orig$colour_levels)) "plot" else "missing"
+	src$colour_levels_cols          <- if (length(orig$colour_levels_cols)) "plot" else "missing"
+	src$fill_levels                 <- if (length(orig$fill_levels)) "plot" else "missing"
+	src$fill_levels_cols            <- if (length(orig$fill_levels_cols)) "plot" else "missing"
+
+	# Text sizes are base defaults
+	src$title_size         <- "base"
+	src$subtitle_size      <- "base"
+	src$caption_size       <- "base"
+	src$axis_title_size    <- "base"
+	src$axis_text_size     <- "base"
+	src$legend_title_size  <- "base"
+	src$legend_text_size   <- "base"
+
+	# Assign to reactive state
+	rv$originals[[index_str]] <- orig
+	rv$originals_src[[index_str]] <- src
 }
 
 # Get plot name for display

--- a/R/panes_originals.R
+++ b/R/panes_originals.R
@@ -1,0 +1,130 @@
+# plot-editor/R/panes_originals.R
+
+originals_pane_ui <- function(rv) {
+	# Always available: this is a read-only inspector
+
+	# Helper to display a value with status (loaded vs missing)
+	show_val <- function(label, val, origin = NULL) {
+		status <- if (is.null(val) || (is.character(val) && length(val) == 0)) "(missing)" else ""
+		val_txt <- if (is.null(val)) "" else if (length(val) > 1) paste(val, collapse = ", ") else as.character(val)
+		div(
+			tags$strong(label), ": ",
+			if (nzchar(val_txt)) code(val_txt) else tags$em(""),
+			if (nzchar(status)) span(style = "color:#999; margin-left:6px;", status) else NULL,
+			if (!is.null(origin)) span(style = "color:#999; margin-left:10px; font-size: 90%;",
+				paste0("[", origin, "]")) else NULL
+		)
+	}
+
+	# Build per-plot panels
+	plot_indices <- names(rv$plots)
+
+	plot_panels <- lapply(plot_indices, function(index) {
+		index_str <- as.character(index)
+		name <- rv$plot_names[[index_str]] %||% paste("Plot", index_str)
+		orig <- rv$originals[[index_str]] %||% list()
+		src  <- rv$originals_src[[index_str]] %||% list()
+
+		# Tabs corresponding to main menu options
+		text_tab <- tagList(
+			show_val("Title", orig$title, src$title),
+			show_val("Subtitle", orig$subtitle, src$subtitle),
+			show_val("Caption", orig$caption, src$caption),
+			show_val("X label", orig$xlab, src$xlab),
+			show_val("Y label", orig$ylab, src$ylab),
+			tags$hr(),
+			show_val("Title size", orig$title_size, src$title_size),
+			show_val("Subtitle size", orig$subtitle_size, src$subtitle_size),
+			show_val("Caption size", orig$caption_size, src$caption_size),
+			show_val("Axis title size", orig$axis_title_size, src$axis_title_size),
+			show_val("Axis text size", orig$axis_text_size, src$axis_text_size),
+			show_val("Legend title size", orig$legend_title_size, src$legend_title_size),
+			show_val("Legend text size", orig$legend_text_size, src$legend_text_size),
+			tags$hr(),
+			show_val("X min", orig$x_min, src$x_min),
+			show_val("X max", orig$x_max, src$x_max),
+			show_val("Y min", orig$y_min, src$y_min),
+			show_val("Y max", orig$y_max, src$y_max),
+			tags$hr(),
+			show_val("X major step", orig$x_step_major, src$x_step_major),
+			show_val("X minor step", orig$x_step_minor, src$x_step_minor),
+			show_val("Y major step", orig$y_step_major, src$y_step_major),
+			show_val("Y minor step", orig$y_step_minor, src$y_step_minor)
+		)
+
+		theme_tab <- tagList(
+			show_val("Base theme", if (!is.null(orig$theme)) "(theme)" else NULL, src$theme),
+			show_val("Base size", orig$base_size, src$base_size),
+			show_val("Legend position", orig$legend_pos, src$legend_pos),
+			show_val("Legend box", orig$legend_box, src$legend_box),
+			tags$hr(),
+			show_val("Panel background", orig$panel_bg, src$panel_bg),
+			show_val("Plot background", orig$plot_bg, src$plot_bg),
+			tags$hr(),
+			show_val("Palette", orig$palette, src$palette),
+			show_val("Continuous colour palette", orig$continuous_colour_palette, src$continuous_colour_palette),
+			show_val("Continuous fill palette", orig$continuous_fill_palette, src$continuous_fill_palette),
+			show_val("Colour levels", orig$colour_levels, src$colour_levels),
+			show_val("Colour levels colors", orig$colour_levels_cols, src$colour_levels_cols),
+			show_val("Fill levels", orig$fill_levels, src$fill_levels),
+			show_val("Fill levels colors", orig$fill_levels_cols, src$fill_levels_cols)
+		)
+
+		export_tab <- tagList(
+			# Export originals use BASE when added; show those defaults for clarity
+			show_val("Width (mm)", BASE$width_mm, "base"),
+			show_val("Height (mm)", BASE$height_mm, "base"),
+			show_val("DPI", BASE$dpi, "base"),
+			show_val("Format", BASE$format, "base")
+		)
+
+		grid_tab <- tagList(
+			show_val("Grid major on", orig$grid_major, src$grid_major),
+			show_val("Grid minor on", orig$grid_minor, src$grid_minor),
+			show_val("Grid major linetype", orig$grid_major_linetype, src$grid_major_linetype),
+			show_val("Grid minor linetype", orig$grid_minor_linetype, src$grid_minor_linetype),
+			show_val("Grid color", orig$grid_color, src$grid_color)
+		)
+
+		shiny::tabPanel(
+			title = name,
+			value = paste0("orig_", index_str),
+			# Sub-tabs mirroring main sections (Text/Theme/Axis/Export)
+			tabsetPanel(
+				id = paste0("originals_tabs_", index_str),
+				selected = rv$tabs$originals %||% "Text",
+				tabPanel("Grid", grid_tab),
+				tabPanel("Export", export_tab),
+				tabPanel("Text", text_tab),
+				tabPanel("Theme", theme_tab)
+			)
+		)
+	})
+
+	# If no plots, show info
+	if (length(plot_panels) == 0) {
+		return(tagList(
+			h4("Original settings"),
+			helpText("Load plots to inspect their original settings.")
+		))
+	}
+
+	# Render as a tabset per plot so the left panel stays compact
+	do.call(tabsetPanel, c(id = "originals_plots", type = "tabs", plot_panels))
+}
+
+register_originals_observers <- function(input, rv, session) {
+	# Persist selected sub-tab (shared across plots)
+	observe({
+		lapply(names(rv$plots), function(index) {
+			local({
+				idx <- as.character(index)
+				input_id <- paste0("originals_tabs_", idx)
+				observeEvent(input[[input_id]], {
+					rv$tabs$originals <- input[[input_id]]
+				}, ignoreInit = TRUE, ignoreNULL = TRUE)
+			})
+		})
+	})
+}
+

--- a/R/server.R
+++ b/R/server.R
@@ -37,6 +37,7 @@ app_server <- function(input, output, session) {
       add_disabled(shinydashboard::menuItem("Export", tabName = "export", icon = icon("download")), ma$export),
       add_disabled(shinydashboard::menuItem("Text",   tabName = "text",   icon = icon("font")), ma$text),
       add_disabled(shinydashboard::menuItem("Theme",  tabName = "theme",  icon = icon("paint-brush")), ma$theme),
+      shinydashboard::menuItem("Original settings", tabName = "originals", icon = icon("history")),
       hr(),
       fileInput("plots_rds", "Load ggplot (.rds, multiple)", accept = ".rds", multiple = TRUE),
       actionButton("load_demo", "Load 3 demo plots", class = "btn btn-link")
@@ -276,6 +277,7 @@ app_server <- function(input, output, session) {
            export = export_pane_ui(rv),
            text   = text_pane_ui(rv),
            theme  = theme_pane_ui(rv),
+           originals = originals_pane_ui(rv),
            div(helpText("Pick a section from the left."))
     )
   })
@@ -287,4 +289,5 @@ app_server <- function(input, output, session) {
   register_text_observers(input, rv, session)
   register_theme_observers(input, rv, session)
   register_export_observers(input, rv, session)
+  register_originals_observers(input, rv, session)
 }

--- a/R/state.R
+++ b/R/state.R
@@ -34,12 +34,14 @@ init_reactive_state <- function() {
       grid = "Layout",
       export = "Settings",
       text = "Content",
-      theme = "Base"
+      theme = "Base",
+      originals = "Text"
     ),
     
     # Plot edits and originals
     edits = list(),
     originals = list(),
+    originals_src = list(),
     
     # Export settings
     export = list(),

--- a/www/style.css
+++ b/www/style.css
@@ -42,6 +42,11 @@ input[type="number"] { padding: 4px 6px; font-size: 12px; }
 /***** Tab panel content *****/
 .tab-pane { padding: 10px 0; }
 
+/* Originals inspector styles */
+.muted-control { opacity: 0.6; }
+.box .tab-content code { background: #f7f7f7; padding: 1px 4px; border-radius: 3px; }
+.box .tab-content em { color: #777; }
+
 /***** Plot/image outputs: remove extra gaps inside boxes only *****/
 .box .shiny-plot-output,
 .box .shiny-image-output {


### PR DESCRIPTION
Add an 'Original settings' menu to display loaded plot settings and their origin to help identify unnecessary overwrites.

---
<a href="https://cursor.com/background-agent?bcId=bc-bca2cb06-7190-44c1-8eba-9065036f787e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bca2cb06-7190-44c1-8eba-9065036f787e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

